### PR TITLE
Remove `no-ink-alloc` feature

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,4 +49,3 @@ ink-generate-abi = [
     "std",
 ]
 old-codec = []
-no-ink-alloc = []

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,7 +49,7 @@
 
 // This extern crate definition is required since otherwise rustc
 // is not recognizing its allocator and panic handler definitions.
-#[cfg(all(not(feature = "std"), not(feature = "no-ink-alloc")))]
+#[cfg(not(feature = "std"))]
 extern crate ink_alloc;
 
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

Revert some code of #1

Use `global_allocator`, `panic_handler` and `alloc_error_handler` of `ink_alloc`. 

PS: Need to disable `global_allocator`, `panic_handler` and `alloc_error_handler` in `sr-io`